### PR TITLE
Fix SEGFAULT on Node::inspect (node_string in C)

### DIFF
--- a/ext/tree_sitter/node.c
+++ b/ext/tree_sitter/node.c
@@ -30,7 +30,9 @@ static VALUE node_end_point(VALUE self) {
 static VALUE node_string(VALUE self) {
   char *str = ts_node_string(SELF);
   VALUE res = safe_str(str);
-  free(str);
+  if (str) {
+    free(str);
+  }
   return res;
 }
 

--- a/ext/tree_sitter/parser.c
+++ b/ext/tree_sitter/parser.c
@@ -80,7 +80,9 @@ static VALUE parser_set_included_ranges(VALUE self, VALUE array) {
     ranges[i] = value_to_range(rb_ary_entry(array, i));
   }
   bool res = ts_parser_set_included_ranges(SELF, ranges, (uint32_t)length);
-  free(ranges);
+  if (ranges) {
+    free(ranges);
+  }
   return res ? Qtrue : Qfalse;
 }
 

--- a/ext/tree_sitter/tree.c
+++ b/ext/tree_sitter/tree.c
@@ -33,7 +33,9 @@ static VALUE tree_changed_ranges(VALUE _self, VALUE old_tree, VALUE new_tree) {
     rb_ary_push(res, new_range(&ranges[i]));
   }
 
-  free(ranges);
+  if (ranges) {
+    free(ranges);
+  }
 
   return res;
 }


### PR DESCRIPTION
`free(NULL)` should work on POSIX without any guards.
See https://pubs.opengroup.org/onlinepubs/009604499/functions/free.html

But for some reason this fixes a SEGFAULT we were having on calls to `node_string. 
It's most likely that someone is redefining `free` somewhere.

The other guards on `free` are just defensive guards. Better safe than on `gdb`.
